### PR TITLE
added new config property to support multiple language identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+.vscode-test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
     "args": ["run", "compile", "--loglevel", "silent"],
 
     // The tsc compiler is started in watching mode
-    "isWatching": true,
+    "isBackground": true,
 
     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
     "problemMatcher": "$tsc-watch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the "perltidy" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.2] - 2020-01-12
+### Added
+- Support for multiple language identifiers
+- Minor improvements to README.md
+
 ## [1.2.1] - 2017-07-27
 ### Added
 - Fix to prevent perpetual processes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This extension is a simple formatter for perl code using Perl::Tidy.
 ## Features
 
 * Format perl code using default formatting command
-* Format on save
+* Format on save (editor.formatOnSave must be true)
 * Format selected text
 * Basic linting
 
@@ -18,6 +18,7 @@ This extension requires that Perl::Tidy is installed.
 To install Perl::Tidy:
 * cpan install Perl::Tidy
 * ppm install Perl-Tidy (if using ActivePerl)
+* brew install perltidy (Mac OS)
 * sudo apt install perltidy -y (Ubuntu)
 * sudo yum install perltidy -y (CentOS)
 
@@ -27,4 +28,5 @@ This extension contributes the following settings:
 
 * `perltidy.executable`: path to perltidy executable
 * `perltidy.profile`: path to .perltidyrc file.
+* `perltidy.languageIdentifiers`: array of language identifiers, allows support for perl+mojolicious
 * `perltidy.additionalArguments`: array listing any additional arguments to be used with the perltidy command

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
           "type": "string",
           "description": "Path to .perltidyrc file"
         },
+        "perltidy.languageIdentifiers": {
+          "type": "array",
+          "default": ["perl"],
+          "description": "Language identifiers"
+        },
         "perltidy.additionalArguments": {
           "type": "array",
           "default": [],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,22 +7,27 @@ export function activate(context: vscode.ExtensionContext) {
 
     let config = vscode.workspace.getConfiguration('perltidy');
     let formatter = new Formatter(config);
+    let languageIdentifiers: string[] = config.get('languageIdentifiers');
 
     vscode.workspace.onWillSaveTextDocument((event: vscode.TextDocumentWillSaveEvent) => {
-        if (event.document.languageId !== 'perl') return;
+        if (
+            languageIdentifiers.indexOf( event.document.languageId ) == -1
+        ) return;
         let stdFormatConfig = vscode.workspace.getConfiguration('editor');
         if (stdFormatConfig && stdFormatConfig['formatOnSave']) {
             event.waitUntil(vscode.commands.executeCommand('editor.action.formatDocument'));
         }
     });
 
-    let provider = vscode.languages.registerDocumentRangeFormattingEditProvider('perl', {
-        provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range): Promise<vscode.TextEdit[]> {
-            return formatter.format(document, range);
-        }
+    languageIdentifiers.forEach( languageIdentifier => {
+        let provider = vscode.languages.registerDocumentRangeFormattingEditProvider(languageIdentifier, {
+            provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range): Promise<vscode.TextEdit[]> {
+                return formatter.format(document, range);
+            }
+        });
+    
+        context.subscriptions.push(provider);
     });
-
-    context.subscriptions.push(provider);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
I use a different language identifier for perl as I'm working on a project which uses https://mojolicious.org/ this means the language identifier isn't "perl"

I'm sure there are other "perl" language identifiers, so thought it would be good to include a config property to allow for multiple identifiers.